### PR TITLE
fix unknown environments polluting config keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function Config(cfg) {
     value: process.env.NODE_ENV || 'development'
   });
 
-  var settings = clone(cfg[this.env]) || cfg;
+  var settings = clone(cfg[this.env]) || {};
   if (cfg['*']) extend(settings, cfg['*']);
 
   Object.keys(settings).forEach(function(key) {


### PR DESCRIPTION
envcfg will mix in the '*' params in unknown environments but will also add keys to the config object for all other environments, so, in the current version, this:

```
var envcfg = require('./');
var cfg = envcfg({
    '*': {
        'my-key-here': 'is-important'
    },
    'someEnv': {
        'dude-bro': 'what is up'
    }
});

console.log(Object.keys(cfg));
console.log(cfg['my-key-here'])
```

Would print:

```
[ '*', 'someEnv', 'my-key-here' ]
is-important
```

Rather than just...

```
[ 'my-key-here' ]
is-important
```

...which is helpful if you, like me, need all available config params.
