### PR TITLE
Nested objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.7
+  - 0.10
+  - 4.2.1

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function read(file) {
 }
 
 /**
- * Extend object `a` with object `b`.
+ * Extend object `a` with object `b`. Now does deep extension.
  *
  * @param {Object} a
  * @param {Object} b
@@ -105,7 +105,11 @@ function read(file) {
 
 function extend(a, b) {
   Object.keys(b).forEach(function(key) {
-    if (!a.hasOwnProperty(key)) a[key] = b[key];
+    if (!a.hasOwnProperty(key)) {
+      a[key] = b[key];
+    } else if (b[key].constructor && b[key].constructor === Object) {
+      a[key] = extend(a[key], b[key]);
+    }
   });
   return a;
 }

--- a/index.js
+++ b/index.js
@@ -39,13 +39,14 @@ exports.Config = Config;
  * @api public
  */
 
-function Config(cfg) {
+function Config(cfg, opts) {
   define(this, 'env', {
     value: process.env.NODE_ENV || 'development'
   });
 
   var settings = clone(cfg[this.env]) || {};
-  if (cfg['*']) extend(settings, cfg['*']);
+
+  if (cfg['*']) extend(settings, cfg['*'], opts.deepMerge);
 
   Object.keys(settings).forEach(function(key) {
     define(this, key, {
@@ -75,9 +76,17 @@ Config.prototype.get = function(key){
  * @api public
  */
 
-function envcfg(config) {
+function envcfg(config, opts) {
+  opts = opts || {};
   config = typeof config === 'string' ? read(config) : config;
-  return Object.freeze(new Config(config));
+  if (opts.mutable === true) {
+    // allow the config object to be modified
+    descriptors.writable = true;
+    descriptors.configurable = true;
+    descriptors.enumerable = true;
+    return new Config(config, opts);
+  }
+  return Object.freeze(new Config(config, opts));
 }
 
 /**
@@ -95,21 +104,28 @@ function read(file) {
 }
 
 /**
- * Extend object `a` with object `b`. Now does deep extension.
+ * Extend object `a` with object `b`. Now does deep extension if deep parameter is true.
  *
  * @param {Object} a
  * @param {Object} b
+ * @param {Boolean} deep
  * @return {Object}
  * @api private
  */
 
-function extend(a, b) {
+function extend(a, b, deep) {
+  if (deep) {
+    Object.keys(b).forEach(function(key) {
+      if (!a.hasOwnProperty(key)) {
+        a[key] = b[key];
+      } else if (b[key].constructor && b[key].constructor === Object) {
+        a[key] = extend(a[key], b[key]);
+      }
+    });
+    return a;
+  }
   Object.keys(b).forEach(function(key) {
-    if (!a.hasOwnProperty(key)) {
-      a[key] = b[key];
-    } else if (b[key].constructor && b[key].constructor === Object) {
-      a[key] = extend(a[key], b[key]);
-    }
+    if (!a.hasOwnProperty(key)) a[key] = b[key];
   });
   return a;
 }
@@ -123,6 +139,6 @@ function extend(a, b) {
  * @api private
  */
 
-function define(context, key, value){
-  Object.defineProperty(context, key, extend(value, descriptors));
+function define(context, key, value, deep){
+  Object.defineProperty(context, key, extend(value, descriptors, deep));
 }

--- a/test/envcfg.test.js
+++ b/test/envcfg.test.js
@@ -79,4 +79,12 @@ describe('envcfg', function() {
 		});
 	});
 
+	describe('#envcfg(nested_object)', function() {
+		it('should create from a nested object', function() {
+			var config = envcfg(require(path.join(__dirname + '/fixtures/nested')));
+			assert.equal(config.nest.bar, 'exam');
+			assert(config.nest.zing);
+		});
+	});
+
 });

--- a/test/envcfg.test.js
+++ b/test/envcfg.test.js
@@ -7,6 +7,7 @@ var assert = require('assert');
 describe('envcfg', function() {
 
 	var config = envcfg(path.join(__dirname + '/fixtures/basic.json'));
+	var mutable = envcfg(path.join(__dirname + '/fixtures/basic.js'), {deepMerge: true, mutable: true});
 
 	describe('#envcfg(path)', function() {
 		it("should create from a json file path", function() {
@@ -52,6 +53,14 @@ describe('envcfg', function() {
 			assert.equal(config.foo, 'foo-test');
 		});
 
+		it('should be possible to change a value', function() {
+			assert.equal(mutable.foo, 'foo-test');
+			assert.equal(mutable.bar, 'bar-test');
+			assert.equal(mutable.buz, 'buzz-*');
+			mutable.foo = 'foo-not-immutable';
+			assert.equal(mutable.foo, 'foo-not-immutable');
+		});
+
 		it('shouvld not be possible to delete values', function() {
 			assert.throws(function() {
 				delete config.foo;
@@ -59,11 +68,21 @@ describe('envcfg', function() {
 			assert.equal(config.foo, 'foo-test');
 		});
 
+		it('should be possible to delete values', function() {
+			delete mutable.foo;
+			assert(!mutable.foo);
+		});
+
 		it('should not be possible to add new values', function() {
-			assert.throws(function(){
+			assert.throws(function() {
 				config.whatever = 'whatever';
 				assert.strictEqual(config.whatever, undefined);
 			}, Error);
+		});
+
+		it('should be possible to add new values', function() {
+			mutable.newValue = 'I didn\'t exist before';
+			assert.equal(mutable.newValue, 'I didn\'t exist before');
 		});
 	});
 
@@ -73,7 +92,7 @@ describe('envcfg', function() {
 		});
 	});
 
-	describe('#.get(key)', function(){
+	describe('#.get(key)', function() {
 		it('should access the property', function(){
 			config.get('some stuff').should.equal('whatever');
 		});
@@ -81,7 +100,7 @@ describe('envcfg', function() {
 
 	describe('#envcfg(nested_object)', function() {
 		it('should create from a nested object', function() {
-			var config = envcfg(require(path.join(__dirname + '/fixtures/nested')));
+			var config = envcfg(require(path.join(__dirname + '/fixtures/nested')), {deepMerge: true});
 			assert.equal(config.nest.bar, 'exam');
 			assert(config.nest.zing);
 		});

--- a/test/fixtures/nested.js
+++ b/test/fixtures/nested.js
@@ -1,0 +1,24 @@
+
+module.exports = exports = {
+	"*": {
+		"foo": "foo-*",
+		"buz": "buzz-*",
+    "nest": {
+      "bar": "none",
+      "zing": "ga"
+    }
+	},
+	"development": {
+		"bar": "bar-development",
+    "nest": {
+      "bar": "exam"
+    }
+	},
+	"test": {
+		"foo": "foo-test",
+		"bar": "bar-test",
+    "nest": {
+      "bar": "exam"
+    }
+	}
+};


### PR DESCRIPTION
This pull request allows deep merging/extending of config objects. Before when a nested object was present in both a specific env like 'dev' and in the default env '*', the object value was just replaced. Now the sub objects in each env config will be merged in the same way as env objects.
